### PR TITLE
feat: append `inCollections` metadata on fetching books

### DIFF
--- a/apis/handler.go
+++ b/apis/handler.go
@@ -1,15 +1,14 @@
 package apis
 
 import (
-	"encoding/json"
 	"errors"
 	"net/http"
-	"strings"
 
 	"github.com/labstack/echo/v5"
 	"github.com/pocketbase/pocketbase"
 	"github.com/pocketbase/pocketbase/core"
 	"tana.moe/momoka-lite/models"
+	"tana.moe/momoka-lite/tools"
 )
 
 type response struct {
@@ -85,25 +84,13 @@ type deleteHandlerFunction func(
 	c echo.Context,
 ) (err error)
 
-func extractExpandMap(c echo.Context) (models.ExpandMap, error) {
-	expandJson := c.QueryParam("expand")
-	if expandJson == "" {
-		return nil, nil
-	}
-	expand := make(models.ExpandMap)
-	if err := json.NewDecoder(strings.NewReader(expandJson)).Decode(&expand); err != nil {
-		return nil, err
-	}
-	return expand, nil
-}
-
 func viewRouteHandler[T comparable](
 	app *pocketbase.PocketBase,
 	e *core.ServeEvent,
 	handler viewHandlerFunction[T],
 ) echo.HandlerFunc {
 	return func(c echo.Context) error {
-		expand, err := extractExpandMap(c)
+		expand, err := tools.ExtractExpandMap(c)
 		if err != nil {
 			return handleError(app, e, c, errors.Join(err, invalidRequestError))
 		}
@@ -146,7 +133,7 @@ func listRouteHandler[T comparable](
 		if listQueryForm.PerPage > 150 {
 			listQueryForm.PerPage = 150
 		}
-		expand, err := extractExpandMap(c)
+		expand, err := tools.ExtractExpandMap(c)
 		if err != nil {
 			return handleError(app, e, c, errors.Join(err, invalidRequestError))
 		}
@@ -183,7 +170,7 @@ func upsertRouteHandler[T comparable](
 	handler upsertHandlerFunction[T],
 ) echo.HandlerFunc {
 	return func(c echo.Context) error {
-		expand, err := extractExpandMap(c)
+		expand, err := tools.ExtractExpandMap(c)
 		if err != nil {
 			return handleError(app, e, c, errors.Join(err, invalidRequestError))
 		}
@@ -209,7 +196,7 @@ func bulkUpsertRouteHandler[T comparable](
 	handler bulkUpsertHandlerFunction[T],
 ) echo.HandlerFunc {
 	return func(c echo.Context) error {
-		expand, err := extractExpandMap(c)
+		expand, err := tools.ExtractExpandMap(c)
 		if err != nil {
 			return handleError(app, e, c, errors.Join(err, invalidRequestError))
 		}

--- a/apis/user_collection.go
+++ b/apis/user_collection.go
@@ -271,10 +271,13 @@ func onCollectionUpsertRequest(
 	if err := form.Submit(); err != nil {
 		return nil, errors.Join(invalidRequestError, err)
 	}
-	if err = item.Expand(app.Dao(), expand); err != nil {
+	if item, err = models.FindCollectionById(app.Dao(), r.Id); err != nil {
 		return nil, err
 	}
-	if item, err = models.FindCollectionById(app.Dao(), r.Id); err != nil {
+	if item == nil {
+		return nil, errors.New("Upserted collection is not suppose to be nil.")
+	}
+	if err = item.Expand(app.Dao(), expand); err != nil {
 		return nil, err
 	}
 	return item, nil
@@ -412,7 +415,7 @@ func onUpsertBookToCollectionRequest(
 		return nil, err
 	}
 	if item == nil {
-		return nil, errors.New("Upserted book to collection not supposed to be nil")
+		return nil, errors.New("Upserted book to collection not supposed to be nil.")
 	}
 	if err = item.Expand(app.Dao(), expand); err != nil {
 		return nil, err

--- a/hooks/hooks.go
+++ b/hooks/hooks.go
@@ -25,5 +25,9 @@ func RegisterHooks(
 		return err
 	}
 
+	if err := registerAppendInCollectionsMetadataHook(app, context); err != nil {
+		return err
+	}
+
 	return nil
 }

--- a/hooks/image_secret.go
+++ b/hooks/image_secret.go
@@ -54,13 +54,12 @@ func appendImageSecret(secret string, record *m.Record) error {
 		return nil
 	}
 
-	record.Set(
-		"metadata",
+	appendMetadata(
+		record,
 		map[string]interface{}{
 			"images": getImageSizes(secret, path),
 		},
 	)
-
 	return nil
 }
 
@@ -75,13 +74,12 @@ func appendImageSliceSecret(secret string, record *m.Record) error {
 		images = append(images, getImageSizes(secret, path))
 	}
 
-	record.Set(
-		"metadata",
+	appendMetadata(
+		record,
 		map[string]interface{}{
 			"images": images,
 		},
 	)
-
 	return nil
 }
 
@@ -130,10 +128,12 @@ func appendImageSizeMetadata(secret string, record *m.Record) error {
 		images = append(images, getImageSizes(secret, path))
 	}
 
-	record.Set("metadata", map[string]interface{}{
-		"images": images,
-	})
-
+	appendMetadata(
+		record,
+		map[string]interface{}{
+			"images": images,
+		},
+	)
 	return nil
 }
 

--- a/hooks/in_collections_metadata.go
+++ b/hooks/in_collections_metadata.go
@@ -1,0 +1,140 @@
+package hooks
+
+import (
+	"database/sql"
+	"errors"
+	"fmt"
+
+	"github.com/pocketbase/dbx"
+	"github.com/pocketbase/pocketbase"
+	"github.com/pocketbase/pocketbase/apis"
+	"github.com/pocketbase/pocketbase/core"
+	"github.com/pocketbase/pocketbase/daos"
+	pmodels "github.com/pocketbase/pocketbase/models"
+	"tana.moe/momoka-lite/models"
+)
+
+func registerAppendInCollectionsMetadataHook(
+	app *pocketbase.PocketBase,
+	context *models.AppContext,
+) error {
+	targetCollections := []string{"books"}
+	app.OnRecordViewRequest(targetCollections...).Add(func(e *core.RecordViewEvent) error {
+		user, _ := e.HttpContext.Get(apis.ContextAuthRecordKey).(*pmodels.Record)
+		if user == nil {
+			return nil
+		}
+		return appendInCollectionsMetadata(app, context, user, [](*pmodels.Record){e.Record})
+	})
+
+	app.OnRecordsListRequest(targetCollections...).Add(func(e *core.RecordsListEvent) error {
+		user, _ := e.HttpContext.Get(apis.ContextAuthRecordKey).(*pmodels.Record)
+		if user == nil {
+			return nil
+		}
+		return appendInCollectionsMetadata(app, context, user, e.Records)
+	})
+
+	return nil
+}
+
+func appendInCollectionsMetadata(
+	app *pocketbase.PocketBase,
+	context *models.AppContext,
+	user *pmodels.Record,
+	records []*pmodels.Record,
+) error {
+	bookToCollectionsMap, err := booksWithBelongCollectionsMap(
+		app.Dao(),
+		user,
+		records,
+	)
+	if err != nil {
+		return err
+	}
+	for _, record := range records {
+		collections, exist := bookToCollectionsMap[record.Id]
+		if !exist {
+			continue
+		}
+		appendMetadata(
+			record,
+			map[string]interface{}{
+				"inCollections": collections,
+			},
+		)
+	}
+	return nil
+}
+
+func booksWithBelongCollectionsMap(
+	dao *daos.Dao,
+	user *pmodels.Record,
+	records []*pmodels.Record,
+) (map[string][]*models.Collection, error) {
+	bookCollections := []struct {
+		*models.Collection
+
+		BookId string `db:"bookId"`
+	}{}
+
+	bookIds := []any{}
+	for _, record := range records {
+		bookIds = append(bookIds, record.Id)
+	}
+
+	collectionTable := (&models.Collection{}).TableName()
+	collectionMemberTable := (&models.CollectionMember{}).TableName()
+	collectionBookTable := (&models.CollectionBook{}).TableName()
+
+	collectionColumns := fmt.Sprintf("%s.*", collectionTable)
+	bookIdColumn := fmt.Sprintf("%s.book as bookId", collectionBookTable)
+
+	err := models.CollectionBookQuery(dao).
+		Select(collectionColumns, bookIdColumn).
+		RightJoin(
+			collectionMemberTable,
+			dbx.And(
+				dbx.NewExp(
+					fmt.Sprintf(
+						"%s.collection = %s.collection",
+						collectionBookTable,
+						collectionMemberTable,
+					),
+				),
+				dbx.HashExp{
+					fmt.Sprintf("%s.user", collectionMemberTable): user.Id,
+				},
+			),
+		).
+		RightJoin(
+			collectionTable,
+			dbx.NewExp(
+				fmt.Sprintf(
+					"%s.collection = %s.id",
+					collectionMemberTable,
+					collectionTable,
+				),
+			),
+		).
+		Where(
+			dbx.HashExp{
+				fmt.Sprintf("%s.book", collectionBookTable): bookIds,
+			},
+		).
+		All(&bookCollections)
+	if errors.Is(err, sql.ErrNoRows) {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, err
+	}
+	collectionMapping := map[string][]*models.Collection{}
+	for _, bookCollection := range bookCollections {
+		collectionMapping[bookCollection.BookId] = append(
+			collectionMapping[bookCollection.BookId],
+			bookCollection.Collection,
+		)
+	}
+	return collectionMapping, nil
+}

--- a/hooks/in_collections_metadata.go
+++ b/hooks/in_collections_metadata.go
@@ -136,6 +136,9 @@ func booksWithBelongCollectionsMap(
 				),
 				dbx.HashExp{
 					fmt.Sprintf("%s.user", collectionMemberTable): user.Id,
+					fmt.Sprintf("%s.role", collectionMemberTable): []any{
+						models.CollectionEditorRole,
+					},
 				},
 			),
 		).

--- a/hooks/in_collections_metadata.go
+++ b/hooks/in_collections_metadata.go
@@ -20,7 +20,7 @@ func registerAppendInCollectionsMetadataHook(
 	app *pocketbase.PocketBase,
 	context *models.AppContext,
 ) error {
-	targetCollections := []string{"books"}
+	targetCollections := []string{"books", "bookDetails"}
 	app.OnRecordViewRequest(targetCollections...).Add(func(e *core.RecordViewEvent) error {
 		user, _ := e.HttpContext.Get(apis.ContextAuthRecordKey).(*pmodels.Record)
 		if user == nil {

--- a/hooks/metadata.go
+++ b/hooks/metadata.go
@@ -13,7 +13,7 @@ func appendMetadata(m *models.Record, data map[string]interface{}) {
 		rawJson = types.JsonRaw{}
 	}
 	metadata := map[string]interface{}{}
-	if len(metadata) > 2 {
+	if len(rawJson.(types.JsonRaw)) > 2 {
 		if err := json.Unmarshal(rawJson.(types.JsonRaw), &metadata); err != nil {
 			panic(err)
 		}

--- a/hooks/metadata.go
+++ b/hooks/metadata.go
@@ -1,0 +1,25 @@
+package hooks
+
+import (
+	"encoding/json"
+
+	"github.com/pocketbase/pocketbase/models"
+	"github.com/pocketbase/pocketbase/tools/types"
+)
+
+func appendMetadata(m *models.Record, data map[string]interface{}) {
+	rawJson := m.Get("metadata")
+	if rawJson == nil {
+		rawJson = types.JsonRaw{}
+	}
+	metadata := map[string]interface{}{}
+	if len(metadata) > 2 {
+		if err := json.Unmarshal(rawJson.(types.JsonRaw), &metadata); err != nil {
+			panic(err)
+		}
+	}
+	for key, value := range data {
+		metadata[key] = value
+	}
+	m.Set("metadata", metadata)
+}

--- a/models/book.go
+++ b/models/book.go
@@ -14,17 +14,18 @@ var _ models.Model = (*Book)(nil)
 type Book struct {
 	models.BaseModel
 
-	PublicationID string                  `db:"publication" json:"publication"`
-	Edition       string                  `db:"edition" json:"edition"`
-	PublishDate   types.DateTime          `db:"publishDate" json:"publishDate"`
-	Covers        types.JsonArray[string] `db:"covers" json:"covers"`
-	Price         int                     `db:"price" json:"price"`
-	Note          string                  `db:"note" json:"note"`
-	Metadata      types.JsonMap           `db:"metadata" json:"metadata"`
+	PublicationID    string                  `db:"publication" json:"publication"`
+	Edition          string                  `db:"edition" json:"edition"`
+	PublishDate      types.DateTime          `db:"publishDate" json:"publishDate"`
+	Covers           types.JsonArray[string] `db:"covers" json:"covers"`
+	Price            int                     `db:"price" json:"price"`
+	Note             string                  `db:"note" json:"note"`
+	Metadata         types.JsonMap           `db:"metadata" json:"metadata"`
+	ParentCollection string                  `db:"parentCollection" json:"parentCollection"`
 }
 
 func (m *Book) TableName() string {
-	return "books"
+	return "bookDetails"
 }
 
 func BookQuery(dao *daos.Dao) *dbx.SelectQuery {

--- a/tools/expand.go
+++ b/tools/expand.go
@@ -1,0 +1,49 @@
+package tools
+
+import (
+	"encoding/json"
+	"strings"
+
+	"github.com/labstack/echo/v5"
+	"tana.moe/momoka-lite/models"
+)
+
+func flatToExpandMap(mapping models.ExpandMap, field string) models.ExpandMap {
+	if len(strings.Split(field, ".")) > 6 {
+		return models.ExpandMap{}
+	}
+	if mapping == nil {
+		mapping = models.ExpandMap{}
+	}
+	dotPos := strings.Index(field, ".")
+	if dotPos <= 1 {
+		mapping[field] = models.ExpandMap{}
+		return mapping
+	}
+	target := field[:dotPos]
+	child := field[(dotPos + 1):]
+	mapping[target] = flatToExpandMap(mapping[target], child)
+	return mapping
+}
+
+func ExtractExpandMap(c echo.Context) (models.ExpandMap, error) {
+	type expandField struct {
+		Expand models.ExpandMap `json:"expand"`
+	}
+	expandJson := c.QueryParam("expand")
+	if expandJson == "" {
+		return nil, nil
+	}
+	if !strings.HasPrefix(expandJson, "{") {
+		expand := make(models.ExpandMap)
+		for _, field := range strings.Split(expandJson, ",") {
+			expand = flatToExpandMap(expand, field)
+		}
+		return expand, nil
+	}
+	expand := make(models.ExpandMap)
+	if err := json.NewDecoder(strings.NewReader(expandJson)).Decode(&expand); err != nil {
+		return nil, err
+	}
+	return expand, nil
+}


### PR DESCRIPTION
- Unify append metadata utility.
- Append `inCollections` metadata on fetching books, which fetch all the collections that the user can edit and contains that book.
- Make `expand` support flat version like `a.b.c` since **PocketBase** support it.
- Change \`Book\` model table name from `books` to `bookDetails` since it had calculated `covers` field.
- Minor bug fixes.