### PR TITLE
chore: correct the way of matching error handling

### DIFF
--- a/models/additional_title_name.go
+++ b/models/additional_title_name.go
@@ -2,6 +2,7 @@ package models
 
 import (
 	"database/sql"
+	"errors"
 
 	"github.com/pocketbase/dbx"
 )
@@ -28,7 +29,7 @@ func FindAdditionalTitleNameById(db dbx.Builder, id string) (*AdditionalTitleNam
 		AndWhere(dbx.HashExp{"id": id}).
 		Limit(1).
 		One(name)
-	if err == sql.ErrNoRows {
+	if errors.Is(err, sql.ErrNoRows) {
 		return nil, nil
 	}
 	if err != nil {

--- a/models/asset.go
+++ b/models/asset.go
@@ -2,6 +2,7 @@ package models
 
 import (
 	"database/sql"
+	"errors"
 
 	"github.com/pocketbase/dbx"
 	"github.com/pocketbase/pocketbase/tools/types"
@@ -33,7 +34,7 @@ func FindAssetById(db dbx.Builder, id string) (*Asset, error) {
 		AndWhere(dbx.HashExp{"id": id}).
 		Limit(1).
 		One(asset)
-	if err == sql.ErrNoRows {
+	if errors.Is(err, sql.ErrNoRows) {
 		return nil, nil
 	}
 	if err != nil {

--- a/models/asset_type.go
+++ b/models/asset_type.go
@@ -2,6 +2,7 @@ package models
 
 import (
 	"database/sql"
+	"errors"
 
 	"github.com/pocketbase/dbx"
 )
@@ -27,7 +28,7 @@ func FindAssetTypeById(db dbx.Builder, id string) (*AssetType, error) {
 		AndWhere(dbx.HashExp{"id": id}).
 		Limit(1).
 		One(assetType)
-	if err == sql.ErrNoRows {
+	if errors.Is(err, sql.ErrNoRows) {
 		return nil, nil
 	}
 	if err != nil {

--- a/models/book.go
+++ b/models/book.go
@@ -35,7 +35,7 @@ func FindBookById(db dbx.Builder, id string) (*Book, error) {
 		AndWhere(dbx.HashExp{"id": id}).
 		Limit(1).
 		One(book)
-	if err == sql.ErrNoRows {
+	if errors.Is(err, sql.ErrNoRows) {
 		return nil, nil
 	}
 	if err != nil {

--- a/models/book_metadata.go
+++ b/models/book_metadata.go
@@ -2,6 +2,7 @@ package models
 
 import (
 	"database/sql"
+	"errors"
 
 	"github.com/pocketbase/dbx"
 )
@@ -33,7 +34,7 @@ func FindBookMetadataById(db dbx.Builder, id string) (*BookMetadata, error) {
 		AndWhere(dbx.HashExp{"id": id}).
 		Limit(1).
 		One(book)
-	if err == sql.ErrNoRows {
+	if errors.Is(err, sql.ErrNoRows) {
 		return nil, nil
 	}
 	if err != nil {

--- a/models/collection.go
+++ b/models/collection.go
@@ -41,7 +41,7 @@ func FindCollectionById(db dbx.Builder, id string) (*Collection, error) {
 		AndWhere(dbx.HashExp{"id": id}).
 		Limit(1).
 		One(collection)
-	if err == sql.ErrNoRows {
+	if errors.Is(err, sql.ErrNoRows) {
 		return nil, nil
 	}
 	if err != nil {
@@ -80,7 +80,7 @@ func FindUserDefaultCollection(db dbx.Builder, userId string) (*Collection, erro
 		}).
 		Limit(1).
 		One(collection)
-	if err == sql.ErrNoRows {
+	if errors.Is(err, sql.ErrNoRows) {
 		return nil, nil
 	}
 	if err != nil {

--- a/models/collection_book.go
+++ b/models/collection_book.go
@@ -2,6 +2,7 @@ package models
 
 import (
 	"database/sql"
+	"errors"
 
 	"github.com/pocketbase/dbx"
 )
@@ -38,7 +39,7 @@ func FindCollectionBookById(db dbx.Builder, id string) (*CollectionBook, error) 
 		AndWhere(dbx.HashExp{"id": id}).
 		Limit(1).
 		One(collectionBook)
-	if err == sql.ErrNoRows {
+	if errors.Is(err, sql.ErrNoRows) {
 		return nil, nil
 	}
 	if err != nil {

--- a/models/collection_member.go
+++ b/models/collection_member.go
@@ -2,6 +2,7 @@ package models
 
 import (
 	"database/sql"
+	"errors"
 
 	"github.com/pocketbase/dbx"
 )
@@ -36,7 +37,7 @@ func FindCollectionMemberById(db dbx.Builder, id string) (*CollectionMember, err
 		AndWhere(dbx.HashExp{"id": id}).
 		Limit(1).
 		One(collectionMember)
-	if err == sql.ErrNoRows {
+	if errors.Is(err, sql.ErrNoRows) {
 		return nil, nil
 	}
 	if err != nil {

--- a/models/demographic.go
+++ b/models/demographic.go
@@ -2,6 +2,7 @@ package models
 
 import (
 	"database/sql"
+	"errors"
 
 	"github.com/pocketbase/dbx"
 )
@@ -26,7 +27,7 @@ func FindDemographicById(db dbx.Builder, id string) (*Demographic, error) {
 		AndWhere(dbx.HashExp{"id": id}).
 		Limit(1).
 		One(demographic)
-	if err == sql.ErrNoRows {
+	if errors.Is(err, sql.ErrNoRows) {
 		return nil, nil
 	}
 	if err != nil {

--- a/models/format.go
+++ b/models/format.go
@@ -2,6 +2,7 @@ package models
 
 import (
 	"database/sql"
+	"errors"
 
 	"github.com/pocketbase/dbx"
 )
@@ -29,7 +30,7 @@ func FindFormatById(db dbx.Builder, id string) (*Format, error) {
 		AndWhere(dbx.HashExp{"id": id}).
 		Limit(1).
 		One(format)
-	if err == sql.ErrNoRows {
+	if errors.Is(err, sql.ErrNoRows) {
 		return nil, nil
 	}
 	if err != nil {

--- a/models/genre.go
+++ b/models/genre.go
@@ -2,6 +2,7 @@ package models
 
 import (
 	"database/sql"
+	"errors"
 
 	"github.com/pocketbase/dbx"
 )
@@ -26,7 +27,7 @@ func FindGenreById(db dbx.Builder, id string) (*Genre, error) {
 		AndWhere(dbx.HashExp{"id": id}).
 		Limit(1).
 		One(genre)
-	if err == sql.ErrNoRows {
+	if errors.Is(err, sql.ErrNoRows) {
 		return nil, nil
 	}
 	if err != nil {

--- a/models/publication.go
+++ b/models/publication.go
@@ -2,6 +2,7 @@ package models
 
 import (
 	"database/sql"
+	"errors"
 
 	"github.com/pocketbase/dbx"
 	"github.com/pocketbase/pocketbase/tools/types"
@@ -34,7 +35,7 @@ func FindPublicationById(db dbx.Builder, id string) (*Publication, error) {
 		AndWhere(dbx.HashExp{"id": id}).
 		Limit(1).
 		One(publication)
-	if err == sql.ErrNoRows {
+	if errors.Is(err, sql.ErrNoRows) {
 		return nil, nil
 	}
 	if err != nil {

--- a/models/publisher.go
+++ b/models/publisher.go
@@ -2,6 +2,7 @@ package models
 
 import (
 	"database/sql"
+	"errors"
 
 	"github.com/pocketbase/dbx"
 )
@@ -28,7 +29,7 @@ func FindPublisherById(db dbx.Builder, id string) (*Publisher, error) {
 		AndWhere(dbx.HashExp{"id": id}).
 		Limit(1).
 		One(publisher)
-	if err == sql.ErrNoRows {
+	if errors.Is(err, sql.ErrNoRows) {
 		return nil, nil
 	}
 	if err != nil {

--- a/models/release.go
+++ b/models/release.go
@@ -2,6 +2,7 @@ package models
 
 import (
 	"database/sql"
+	"errors"
 
 	"github.com/pocketbase/dbx"
 )
@@ -53,7 +54,7 @@ func FindReleaseById(db dbx.Builder, id string) (*Release, error) {
 		AndWhere(dbx.HashExp{"id": id}).
 		Limit(1).
 		One(release)
-	if err == sql.ErrNoRows {
+	if errors.Is(err, sql.ErrNoRows) {
 		return nil, nil
 	}
 	if err != nil {

--- a/models/staff.go
+++ b/models/staff.go
@@ -2,6 +2,7 @@ package models
 
 import (
 	"database/sql"
+	"errors"
 
 	"github.com/pocketbase/dbx"
 )
@@ -25,7 +26,7 @@ func FindStaffById(db dbx.Builder, id string) (*Staff, error) {
 		AndWhere(dbx.HashExp{"id": id}).
 		Limit(1).
 		One(staff)
-	if err == sql.ErrNoRows {
+	if errors.Is(err, sql.ErrNoRows) {
 		return nil, nil
 	}
 	if err != nil {

--- a/models/state.go
+++ b/models/state.go
@@ -2,6 +2,7 @@ package models
 
 import (
 	"database/sql"
+	"errors"
 
 	"github.com/pocketbase/dbx"
 )
@@ -30,7 +31,7 @@ func FindStateById(db dbx.Builder, id string) (*State, error) {
 		AndWhere(dbx.HashExp{"id": id}).
 		Limit(1).
 		One(assetType)
-	if err == sql.ErrNoRows {
+	if errors.Is(err, sql.ErrNoRows) {
 		return nil, nil
 	}
 	if err != nil {

--- a/models/title.go
+++ b/models/title.go
@@ -2,6 +2,7 @@ package models
 
 import (
 	"database/sql"
+	"errors"
 
 	"github.com/pocketbase/dbx"
 	"github.com/pocketbase/pocketbase/tools/types"
@@ -39,7 +40,7 @@ func FindTitleById(db dbx.Builder, id string) (*Title, error) {
 		AndWhere(dbx.HashExp{"id": id}).
 		Limit(1).
 		One(title)
-	if err == sql.ErrNoRows {
+	if errors.Is(err, sql.ErrNoRows) {
 		return nil, nil
 	}
 	if err != nil {

--- a/models/user.go
+++ b/models/user.go
@@ -2,6 +2,7 @@ package models
 
 import (
 	"database/sql"
+	"errors"
 
 	"github.com/pocketbase/dbx"
 )
@@ -30,7 +31,7 @@ func FindUserById(db dbx.Builder, id string) (*User, error) {
 		AndWhere(dbx.HashExp{"id": id}).
 		Limit(1).
 		One(user)
-	if err == sql.ErrNoRows {
+	if errors.Is(err, sql.ErrNoRows) {
 		return nil, nil
 	}
 	if err != nil {

--- a/models/work.go
+++ b/models/work.go
@@ -2,6 +2,7 @@ package models
 
 import (
 	"database/sql"
+	"errors"
 
 	"github.com/pocketbase/dbx"
 )
@@ -28,7 +29,7 @@ func FindWorkById(db dbx.Builder, id string) (*Work, error) {
 		AndWhere(dbx.HashExp{"id": id}).
 		Limit(1).
 		One(work)
-	if err == sql.ErrNoRows {
+	if errors.Is(err, sql.ErrNoRows) {
 		return nil, nil
 	}
 	if err != nil {


### PR DESCRIPTION
Replace all the usage of `err == error` as mentioned in #127 issue